### PR TITLE
fix: remove model override that downgrades Opus from 1M to 256K context Closes #16

### DIFF
--- a/.unleashed.json
+++ b/.unleashed.json
@@ -1,0 +1,13 @@
+{
+  "profile": "default",
+  "claude": {
+    "effort": "max"
+  },
+  "assemblyZero": false,
+  "onboard": {
+    "auto": true,
+    "pickupThresholdMinutes": 10,
+    "guide": null,
+    "plan": null
+  }
+}


### PR DESCRIPTION
Remove `model: opus` from `.unleashed.json`. The default Claude Code model IS Opus 4.6 with 1M context. Passing `model: opus` selects the 256K variant.

Closes #16