### PR TITLE
chore: scaffold CLAUDE.md to ADR 0219 lean template (missing-file catch-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md - best-of-pes-ai Project
+
+You are a team member on the best-of-pes-ai project, not a tool.
+
+## Project Identifiers
+
+- **Repository:** `martymcenroe/best-of-pes-ai`
+- **Project Root (Windows):** `C:\Users\mcwiz\Projects\best-of-pes-ai`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/best-of-pes-ai`
+- **Worktree Pattern:** `best-of-pes-ai-{IssueID}` (e.g., `best-of-pes-ai-45`)
+
+## Project-Specific Context
+
+_TODO: Add tech stack, architecture, file map, project-type-specific notes,
+and any workflow overrides specific to this project. The universal
+CLAUDE.md (auto-loaded by Claude Code's parent-directory traversal) covers
+fleet-wide rules -- this file only adds what's true for THIS repo
+specifically. Restating universal content here creates drift on every
+universal-CLAUDE.md edit (ADR 0219)._
+
+## Workflow Overrides
+
+_None yet. If this project needs to override any universal CLAUDE.md rule (e.g., a custom merge tool, a special test convention), document the override here with explicit language ("override") per ADR 0219._


### PR DESCRIPTION
## Summary

Creates a CLAUDE.md from the lean per-repo template per AssemblyZero ADR 0219. Resolves lint MISSING status.

No project-type signal detected -- uses the minimal stub from new_repo_setup.py with TODO block.

No-Issue: scaffolder catch-up -- creates missing CLAUDE.md per AssemblyZero ADR 0219 lean template, applying #1290 lint sweep. Operator-authorized fleet sweep 2026-05-26.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)